### PR TITLE
Spelling

### DIFF
--- a/src/display/screen.cpp
+++ b/src/display/screen.cpp
@@ -1023,7 +1023,7 @@ void Screen::pageDown()
         // increment active page number
         currentPage++;
 
-        // get non fitlered event set
+        // get non filtered event set
         eventList = storageEngine->QueryByEventsinPage(config->pids, getCurrentPage(), getTotalLines(), screenConfig.getColumnSort(), screenConfig.getColumnAscending(), config->events);
     }
 

--- a/src/storage/sqlite3_storage_engine.cpp
+++ b/src/storage/sqlite3_storage_engine.cpp
@@ -70,7 +70,7 @@ Sqlite3StorageEngine::~Sqlite3StorageEngine()
  *  The database connection isn't open and ready flag set to false.
  *
  * Post:
- *  Assuming the storage engine hasn't been initialzied already, opens a 
+ *  Assuming the storage engine hasn't been initialized already, opens a 
  *  Sqlite3 database connection for all data elements and set the ready 
  *  flag to true.
  */

--- a/src/storage/sqlite3_storage_engine.cpp
+++ b/src/storage/sqlite3_storage_engine.cpp
@@ -85,7 +85,7 @@ bool Sqlite3StorageEngine::Initialize(const std::vector<Event>& syscalls)
         return false;
 
     // We only create a single table for all events since there is no expected
-    // perf gains by using a seperate table for each syscall.
+    // perf gains by using a separate table for each syscall.
     rc = sqlite3_exec(dbConnection, SQL_CREATE_EBPF, 0, 0, nullptr);
     if (rc != SQLITE_OK)
         return false;

--- a/src/storage/sqlite3_storage_engine.cpp
+++ b/src/storage/sqlite3_storage_engine.cpp
@@ -557,7 +557,7 @@ std::vector<ITelemetry> Sqlite3StorageEngine::QueryByResultCodeInTimespan(
 
 /**
  * Primary querying function utilized by the UI to support column sorting both in
- * ascending and descengind order.
+ * ascending and descending order.
  * 
  * Pre:
  *  The database connection associated to the given syscall should already be open. 

--- a/src/storage/test_sqlite3_storage_engine.cpp
+++ b/src/storage/test_sqlite3_storage_engine.cpp
@@ -381,16 +381,16 @@ TEST_CASE("storage engine can store and retrieve items at the same time", "[Sqli
             std::vector<MockTelemetry> results;
             while (matchedTimes < 2) 
             {
-                uint accumlated = 0;
+                uint accumulated = 0;
                 bool allTrue = true;
                 for(int res = -20; res <= 20; res++)
                 {
                     REQUIRE_NOTHROW(results = engine.QueryByResultCodeInTimespan(res));
-                    accumlated += results.size();
+                    accumulated += results.size();
                     allTrue = allTrue && checkMatches(results, seenProcesses, pids, resFreq[res]);
                 }
 
-                if (accumlated == elementCount && allTrue)
+                if (accumulated == elementCount && allTrue)
                     matchedTimes += 1;
             }
         }));

--- a/src/storage/test_sqlite3_storage_engine.cpp
+++ b/src/storage/test_sqlite3_storage_engine.cpp
@@ -233,7 +233,7 @@ TEST_CASE("storage engine can retrieve added items", "[Sqlite3StorageEngine]") {
         CHECK(checkMatches(results, seenProcesses, pids, count));
     }
 
-    SECTION("Querying without any pid and specified page constaints returns expected results") {
+    SECTION("Querying without any pid and specified page constraints returns expected results") {
         auto pageNum = 0;
         auto eventsPerPage = 100;
         auto results = engine.QueryByEventsinPage({}, pageNum++, eventsPerPage, ScreenConfiguration::time, true);
@@ -247,14 +247,14 @@ TEST_CASE("storage engine can retrieve added items", "[Sqlite3StorageEngine]") {
         CHECK(checkMatches(results, seenProcesses, pids, eventsPerPage));
     }
 
-    SECTION("Querying with a single pid and specified page constaints returns expected results") {
+    SECTION("Querying with a single pid and specified page constraints returns expected results") {
         auto pageNum = 0;
         auto eventsPerPage = 100;
         auto results = engine.QueryByEventsinPage({1000}, pageNum, eventsPerPage, ScreenConfiguration::time, true);
         CHECK((checkMatches(results, seenProcesses, pids, eventsPerPage) || checkMatches(results, seenProcesses, pids, pidFreq[1000])));
     }
 
-    SECTION("Querying with a set of pids and specified page constaints returns expected results") {
+    SECTION("Querying with a set of pids and specified page constraints returns expected results") {
         auto pageNum = 0;
         auto eventsPerPage = 100;
         auto results = engine.QueryByEventsinPage({1000, 1005, 1006, 1008}, pageNum, eventsPerPage, ScreenConfiguration::time, true);


### PR DESCRIPTION
Misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

It reported: https://github.com/jsoref/ProcMon-for-Linux/commit/904c26ddb4ac1b7d8911f048188f2bb53f6afbca#commitcomment-40982886

And it validated that the changes in this PR made it happy: https://github.com/jsoref/ProcMon-for-Linux/commit/ec187e6537cf3c3c5947ed9746f1a2bed7300c37

Note: this PR does not include the action, if you're interested, that can be offered separately.