### PR TITLE
building against 0.15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(FetchContent)
 FetchContent_Declare(
   bcc
   GIT_REPOSITORY https://github.com/iovisor/bcc.git
-  GIT_TAG        v0.10.0
+  GIT_TAG        v0.15.0
 )
 
 FetchContent_GetProperties(bcc)
@@ -51,6 +51,7 @@ FetchContent_MakeAvailable(Catch2)
 # Set compiler flags.
 set (CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -g -fno-omit-frame-pointer -DELPP_THREAD_SAFE -D ELPP_DEFAULT_LOG_FILE='\"/var/log/procmon.log\"'")
 set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Include required versioning, bcc, logging and sqlite3 header files. 
 include_directories(
@@ -86,9 +87,9 @@ target_link_libraries(
   configuration-static
   tracer-static
   storage-static
+  display-static 
   common-static
   bcc-static
-  display-static 
   ${CURSES_LIBRARIES}
   -lpanel
   logging-static

--- a/src/display/screen.cpp
+++ b/src/display/screen.cpp
@@ -455,7 +455,7 @@ void Screen::run()
 
                 // handle mouse events
                 case KEY_MOUSE:
-                    if(getmouse(&mouseEvent) == OK) handleMouseEvent(&mouseEvent);
+                    if(getmouse(&mouseEvent) == NCURSES_OK) handleMouseEvent(&mouseEvent);
                     if(detailViewActive) showDetailView();
                     break;
                 

--- a/src/display/screen.h
+++ b/src/display/screen.h
@@ -5,6 +5,15 @@
 #define SCREEN_H
 
 #include <ncurses.h>
+
+/* 
+ * Due to a conflict with ncurses OK macro and ebpf::StatusTuple::OK() 
+ * we have to undef OK and define a NCURSES_OK which is equivalent to 
+ * ncurses OK.
+ */
+#undef OK
+#define NCURSES_OK 0
+
 #include <panel.h>
 #include <vector>
 #include <unordered_map>

--- a/src/display/screen_configuration.h
+++ b/src/display/screen_configuration.h
@@ -7,6 +7,10 @@
 #define MAX_COLUMNS 5
 
 #include <ncurses.h>
+
+#undef OK
+#define NCURSES_OK 0
+
 #include <math.h>
 
 class ScreenConfiguration

--- a/src/tracer/ebpf/ebpf_tracer_engine.cpp
+++ b/src/tracer/ebpf/ebpf_tracer_engine.cpp
@@ -11,6 +11,7 @@
 
 bcc_symbol_option EbpfTracerEngine::SymbolOption = {.use_debug_file = 1,
                                                     .check_debug_file_crc = 1,
+						    .lazy_symbolize = 1,
                                                     .use_symbol_type = (1 << STT_FUNC) | (1 << STT_GNU_IFUNC)};
 
 EbpfTracerEngine::EbpfTracerEngine(std::shared_ptr<IStorageEngine> storageEngine, std::vector<Event> targetEvents)


### PR DESCRIPTION
Bumps the BCC version to 0.15.0.

There was a nasty little issue where the `OK` macro in ncurses would expand inside BCC since there was an `OK` function in there that would end up having name in the signature replaced with the symbol `0`.