### PR TITLE
Add nullptr check for some pointer returning functions.

### DIFF
--- a/src/display/screen.cpp
+++ b/src/display/screen.cpp
@@ -661,7 +661,16 @@ void Screen::drawHeader()
 void Screen::initFooter()
 {
     footerWin = newwin(FOOTER_HEIGHT, screenW, screenH - 1, FOOTER_X);
+    if(footerWin == nullptr){
+        LOG(ERROR) << "footerWin is NULL";
+        return;
+    }
+    
     footerPanel = new_panel(footerWin);
+    if(footerPanel == nullptr) {
+        LOG(ERROR) << "footerPanel is NULL";
+        return;
+    }
 
     // print f-key controls
     drawFooterFkeys();
@@ -845,8 +854,15 @@ void Screen::initStatView()
     int statWindow_X = screenW / 6;
 
     statWin = newwin(statWindowHeight, statWindowWidth, statWindow_Y, statWindow_X);
-    statPanel = new_panel(statWin);
+    if(statWin == nullptr){
+        LOG(ERROR) << "statWin is NULL";
+        return;
+    }
 
+    statPanel = new_panel(statWin);
+    if(statPanel == nullptr){
+        LOG(ERROR) << "statPanel is NULL";
+    }
     statViewActive = false;
 
     hide_panel(statPanel);
@@ -860,8 +876,17 @@ void Screen::initHelpView()
     int helpWindow_X = screenW / 6;
 
     helpWin = newwin(helpWindowHeight, helpWindowWidth, helpWindow_Y, helpWindow_X);
-    helpPanel = new_panel(helpWin);
+    if(helpWin == nullptr){
+        LOG(ERROR) << "helpWin is NULL";
+        return;
+    }
 
+    helpPanel = new_panel(helpWin);
+    if(helpPanel == nullptr){
+        LOG(ERROR) << "helpPanel is NULL";
+        return;
+    }
+    
     helpViewActive = false;
 
     hide_panel(helpPanel);
@@ -876,7 +901,16 @@ void Screen::initDetailView()
     int detailWindow_X = screenW / 6;
 
     detailWin = newwin(detailWindowHeight, detailWindowWidth, detailWindow_Y, detailWindow_X);
+    if(detailWin == nullptr){
+        LOG(ERROR) << "detailWin is NULL";
+        return;
+    }
+
     detailPanel = new_panel(detailWin);
+    if(detailPanel == nullptr){
+        LOG(ERROR) << "detailPanel is NULL";
+        return;
+    }
 
     detailViewActive = false;
 
@@ -1819,6 +1853,11 @@ void Screen::windowPrintFillRight(WINDOW * win, int colorPair, int x, int y, con
 
     // allocate memory to print string
     buffer = (char*)malloc(sizeof(char) * maximumX);
+
+    if(buffer == nullptr){
+        LOG(ERROR) << "buffer is null";
+        return;
+    }
 
     // print string to buffer
     va_list args;

--- a/src/display/screen.cpp
+++ b/src/display/screen.cpp
@@ -862,6 +862,7 @@ void Screen::initStatView()
     statPanel = new_panel(statWin);
     if(statPanel == nullptr){
         LOG(ERROR) << "statPanel is NULL";
+        return;
     }
     statViewActive = false;
 

--- a/src/logging/easylogging++.cc
+++ b/src/logging/easylogging++.cc
@@ -1019,12 +1019,17 @@ char* Str::wcharPtrToCharPtr(const wchar_t* line) {
   std::size_t len_ = wcslen(line) + 1;
   char* buff_ = static_cast<char*>(malloc(len_ + 1));
 #      if ELPP_OS_UNIX || (ELPP_OS_WINDOWS && !ELPP_CRT_DBG_WARNINGS)
-  std::wcstombs(buff_, line, len_);
+  if(buff_ != nullptr){
+    std::wcstombs(buff_, line, len_);
+  }
+  
 #      elif ELPP_OS_WINDOWS
   std::size_t convCount_ = 0;
   mbstate_t mbState_;
   ::memset(static_cast<void*>(&mbState_), 0, sizeof(mbState_));
-  wcsrtombs_s(&convCount_, buff_, len_, &line, len_, &mbState_);
+  if(buff_ != nullptr){
+    wcsrtombs_s(&convCount_, buff_, len_, &line, len_, &mbState_);
+  }
 #      endif  // ELPP_OS_UNIX || (ELPP_OS_WINDOWS && !ELPP_CRT_DBG_WARNINGS)
   return buff_;
 }
@@ -2261,8 +2266,10 @@ void DefaultLogDispatchCallback::dispatch(base::type::string_t&& logLine) {
       sysLogPriority = LOG_NOTICE;
 #  if defined(ELPP_UNICODE)
     char* line = base::utils::Str::wcharPtrToCharPtr(logLine.c_str());
-    syslog(sysLogPriority, "%s", line);
-    free(line);
+    if(line != nullptr){
+      syslog(sysLogPriority, "%s", line);
+      free(line);
+    }
 #  else
     syslog(sysLogPriority, "%s", logLine.c_str());
 #  endif
@@ -2371,8 +2378,11 @@ void AsyncDispatchWorker::handle(AsyncLogItem* logItem) {
       sysLogPriority = LOG_NOTICE;
 #      if defined(ELPP_UNICODE)
     char* line = base::utils::Str::wcharPtrToCharPtr(logLine.c_str());
-    syslog(sysLogPriority, "%s", line);
-    free(line);
+    if(line != nullptr){
+      syslog(sysLogPriority, "%s", line);
+      free(line);
+    }
+    
 #      else
     syslog(sysLogPriority, "%s", logLine.c_str());
 #      endif
@@ -2518,8 +2528,11 @@ MessageBuilder& MessageBuilder::operator<<(const wchar_t* msg) {
   m_logger->stream() << msg;
 #  else
   char* buff_ = base::utils::Str::wcharPtrToCharPtr(msg);
-  m_logger->stream() << buff_;
-  free(buff_);
+  if(buff_ != nullptr){
+    m_logger->stream() << buff_;
+    free(buff_);
+  }
+  
 #  endif
   if (ELPP->hasFlag(LoggingFlag::AutoSpacing)) {
     m_logger->stream() << " ";

--- a/src/storage/sqlite3_storage_engine.cpp
+++ b/src/storage/sqlite3_storage_engine.cpp
@@ -210,6 +210,9 @@ ITelemetry Sqlite3StorageEngine::parseSqlite3Row(sqlite3_stmt *preppedSqlStmt)
             // Interestingly enough, if we don't copy the blob we get back from sqlite it can eventually
             // reuse that memory buffer and change the contents of the record.
             datam.arguments = (unsigned char*) malloc(MAX_BUFFER);
+            if(datam.arguments == nullptr){
+                break; // I'm not sure if breaking is the right way of handling nullptr here.
+            }
             memcpy(datam.arguments, arguments, MAX_BUFFER);
         }
         else if (columnName == "timestamp")

--- a/src/sym/bcc_proc.cpp
+++ b/src/sym/bcc_proc.cpp
@@ -119,16 +119,19 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
 
     if (sb.st_ino == inum) {
       char *pid_fd_path = (char*) malloc(strlen(path_buffer) + 1);
-      if(pid_fd_path == nullptr){
-        return NULL; 
+      if(pid_fd_path == nullptr){,
+        break;
       }
       strcpy(pid_fd_path, path_buffer);
       path = pid_fd_path;
     }
   }
-  closedir(dirstream);
-  free(dirstr);
-
+  if(dirstream){
+    closedir(dirstream);
+  }
+  if(dirstr){
+    free(dirstr);
+  }
   return path;
 }
 

--- a/src/sym/bcc_proc.cpp
+++ b/src/sym/bcc_proc.cpp
@@ -101,6 +101,9 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
 
   snprintf(path_buffer, (PATH_MAX + 1), "/proc/%d/fd", pid);
   dirstr = (char*) malloc(strlen(path_buffer) + 1);
+  if(dirstr == nullptr){
+    return NULL;
+  }
   strcpy(dirstr, path_buffer);
   dirstream = opendir(dirstr);
 
@@ -116,6 +119,9 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
 
     if (sb.st_ino == inum) {
       char *pid_fd_path = (char*) malloc(strlen(path_buffer) + 1);
+      if(pid_fd_path == nullptr){
+        return NULL; 
+      }
       strcpy(pid_fd_path, path_buffer);
       path = pid_fd_path;
     }
@@ -361,6 +367,9 @@ static int read_cache1(const char *ld_map) {
 
   lib_cache =
       (struct ld_lib *)malloc(ldcache->entry_count * sizeof(struct ld_lib));
+  if(lib_cache == nullptr ){
+    return -1;
+  }
   lib_cache_count = (int)ldcache->entry_count;
 
   for (i = 0; i < ldcache->entry_count; ++i) {
@@ -384,6 +393,10 @@ static int read_cache2(const char *ld_map) {
 
   lib_cache =
       (struct ld_lib *)malloc(ldcache->entry_count * sizeof(struct ld_lib));
+  if(lib_cache == nullptr){
+    return -1;
+  }
+
   lib_cache_count = (int)ldcache->entry_count;
 
   for (i = 0; i < ldcache->entry_count; ++i) {

--- a/src/sym/bcc_proc.cpp
+++ b/src/sym/bcc_proc.cpp
@@ -119,7 +119,7 @@ static char *_procutils_memfd_path(const int pid, const uint64_t inum) {
 
     if (sb.st_ino == inum) {
       char *pid_fd_path = (char*) malloc(strlen(path_buffer) + 1);
-      if(pid_fd_path == nullptr){,
+      if(pid_fd_path == nullptr){
         break;
       }
       strcpy(pid_fd_path, path_buffer);

--- a/src/tracer/ebpf/ebpf_tracer_engine.cpp
+++ b/src/tracer/ebpf/ebpf_tracer_engine.cpp
@@ -547,6 +547,11 @@ void EbpfTracerEngine::Consume()
 
         tel.duration = event->duration_ns;
         tel.arguments = (unsigned char*) malloc(MAX_BUFFER);
+        if(tel.arguments == nullptr){
+            LOG(ERROR) << "tell.arguments is NULL";
+            return;
+        }
+
         memset(tel.arguments, 0, MAX_BUFFER);
         memcpy(tel.arguments, event->buffer, MAX_BUFFER);
         tel.timestamp = event->timestamp;


### PR DESCRIPTION
Hello, I have been studying your code base and wanted to write some of the missing null-pointer checks that caught my attention.
Note: This PR only focuses on checking return values of some pointer-returning functions.  It doesn't add any checking addition for the functions that take pointers as arguments. However, some of them are also suffering from this.

Thank you,
Umut