### PR TITLE
Add missing standard library includes to screen.h

### DIFF
--- a/src/display/screen.h
+++ b/src/display/screen.h
@@ -28,6 +28,10 @@
 #define NCURSES_OK 0
 
 #include <panel.h>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
 #include <vector>
 #include <unordered_map>
 


### PR DESCRIPTION
Hi, 

I was looking through the codebase and wanted to add some missing standard library includes that caught my attention in `src/display/screen.h`.

I added the following to make sure the file works properly on its own:
- `<cstdint>` for `uint64_t`
- `<map>` for `std::map`
- `<memory>` for `std::shared_ptr`
- `<string>` for `std::string`

Note: This PR focuses only on adding missing includes to `screen.h` so it doesn't rely on other files. It doesn't check for missing includes in other header files across the project. However, some of them might be suffering from this issue as well.

Thanks,
Cevdet Samed/DotChas